### PR TITLE
No global

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node_modules/.bin/nodemon -L app.js",
+	"test": "node_modules/.bin/mocha --recursive test/"
   },
   "dependencies": {
     "body-parser": "~1.15.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node_modules/.bin/nodemon -L app.js",
-	"test": "node_modules/.bin/mocha --recursive test/"
+    "test": "node_modules/.bin/mocha --recursive test/"
   },
   "dependencies": {
     "body-parser": "~1.15.1",
@@ -20,10 +20,12 @@
     "serve-favicon": "~2.3.0"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-http": "^3.0.0",
     "install": "^0.8.1",
-    "nodemon": "^1.10.2",
     "mocha": "^3.1.2",
-    "sequelize": "~3.24.3",
-    "npm": "^3.10.8"
+    "nodemon": "^1.10.2",
+    "npm": "^3.10.8",
+    "sequelize": "~3.24.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "nodemon -L app.js",
     "test": "mocha --recursive test/",
-    "sql": "sequelize"
+    "sql": "node_modules/.bin/sequelize"
   },
   "dependencies": {
     "body-parser": "~1.15.1",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node_modules/.bin/nodemon -L app.js",
-    "test": "node_modules/.bin/mocha --recursive test/"
+    "start": "nodemon -L app.js",
+    "test": "mocha --recursive test/"
   },
   "dependencies": {
     "body-parser": "~1.15.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "nodemon -L app.js",
-    "test": "mocha --recursive test/"
+    "test": "mocha --recursive test/",
+    "sql": "sequelize"
   },
   "dependencies": {
     "body-parser": "~1.15.1",
@@ -26,6 +27,7 @@
     "mocha": "^3.1.2",
     "nodemon": "^1.10.2",
     "npm": "^3.10.8",
-    "sequelize": "~3.24.3"
+    "sequelize": "~3.24.3",
+    "sequelize-cli": "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "nodemon -L app.js",
     "test": "mocha --recursive test/",
-    "sql": "node_modules/.bin/sequelize"
+    "sql": "sequelize"
   },
   "dependencies": {
     "body-parser": "~1.15.1",

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     "fs": "0.0.1-security",
     "hjs": "~0.0.6",
     "less-middleware": "1.0.x",
-    "mocha": "^3.1.2",
     "morgan": "~1.7.0",
     "pg": "~6.1.0",
-    "sequelize": "~3.24.3",
     "serve-favicon": "~2.3.0"
   },
   "devDependencies": {
     "install": "^0.8.1",
     "nodemon": "^1.10.2",
+    "mocha": "^3.1.2",
+    "sequelize": "~3.24.3",
     "npm": "^3.10.8"
   }
 }


### PR DESCRIPTION
-Edited npm script object:

npm start - uses nodemon
npm test - runs the tests without needing to have mocha, chai, chai-http, or other drinks installed globally
npm run sql - equivalent to sequelize, but does not require a global install

-Moved mocha and sequelize to dev dependencies
-Added stuff that used to be global to dev dependencies.